### PR TITLE
Add: ruff to dev dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[tests,dev]"
+      
+      - name: Install ruff
+        run: python -m pip install ruff
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ Download = "https://pypi.org/project/ubc_mds_helper/#files"
 dev = [
     "hatch",
     "pre-commit",
+    "ruff",
 ]
 
 docs = [


### PR DESCRIPTION
I noticed that the status-test-function branch didn't pass one test, because the ruff wasn't in the dev dependencies. 
So I added the line on the pyproject.toml file (as stated from the teacher file as well, it was missing in ours) and edited the deploy.yml, so now all the tests should pass correctly.

If any problem let me know!
